### PR TITLE
Add GPU example to flux-gcp

### DIFF
--- a/fluxfw-gcp/tf/examples/gpu/README.md
+++ b/fluxfw-gcp/tf/examples/gpu/README.md
@@ -1,0 +1,24 @@
+# Flux Framework GPU Example
+
+This example illustrates the creation of a basic cluster of Compute Engine instances with the
+Flux Framework resource job management software deployed across them. The example also illustrates
+the modular construction of the system, deploying and configuring components separately and
+then composing them using Terraform remote state.
+
+## Overview
+
+The components of the example HPC system to be deployed are
+
+- the network and associated NAT and firewall rules
+- the IAM service accounts to be used by the system components
+- the NFS exported /home directory for all of the cluster nodes
+- the cluster nodes, management, login, and compute
+
+Each component is deployed separately and the resources it provides are shared via Terraform remote state.
+
+The deployments occur in the following order and are described in detail in the corresponding component directories
+
+1. [network](https://github.com/GoogleCloudPlatform/scientific-computing-examples/tree/main/fluxfw-gcp/tf/examples/gpu/network)
+1. [iam](https://github.com/GoogleCloudPlatform/scientific-computing-examples/tree/main/fluxfw-gcp/tf/examples/gpu/iam)
+1. [storage](https://github.com/GoogleCloudPlatform/scientific-computing-examples/tree/main/fluxfw-gcp/tf/examples/gpu/storage)
+1. [cluster](https://github.com/GoogleCloudPlatform/scientific-computing-examples/tree/main/fluxfw-gcp/tf/examples/gpu/cluster)

--- a/fluxfw-gcp/tf/examples/gpu/README.md
+++ b/fluxfw-gcp/tf/examples/gpu/README.md
@@ -18,7 +18,7 @@ Each component is deployed separately and the resources it provides are shared v
 
 The deployments occur in the following order and are described in detail in the corresponding component directories
 
-1. [network](https://github.com/GoogleCloudPlatform/scientific-computing-examples/tree/main/fluxfw-gcp/tf/examples/gpu/network)
-1. [iam](https://github.com/GoogleCloudPlatform/scientific-computing-examples/tree/main/fluxfw-gcp/tf/examples/gpu/iam)
-1. [storage](https://github.com/GoogleCloudPlatform/scientific-computing-examples/tree/main/fluxfw-gcp/tf/examples/gpu/storage)
-1. [cluster](https://github.com/GoogleCloudPlatform/scientific-computing-examples/tree/main/fluxfw-gcp/tf/examples/gpu/cluster)
+1. [network](https://github.com/GoogleCloudPlatform/scientific-computing-examples/fluxfw-gcp/tf/examples/gpu/network)
+1. [iam](https://github.com/GoogleCloudPlatform/scientific-computing-examples/fluxfw-gcp/tf/examples/gpu/iam)
+1. [storage](https://github.com/GoogleCloudPlatform/scientific-computing-examples/fluxfw-gcp/tf/examples/gpu/storage)
+1. [cluster](https://github.com/GoogleCloudPlatform/scientific-computing-examples/fluxfw-gcp/tf/examples/gpu/cluster)

--- a/fluxfw-gcp/tf/examples/gpu/README.md
+++ b/fluxfw-gcp/tf/examples/gpu/README.md
@@ -18,7 +18,7 @@ Each component is deployed separately and the resources it provides are shared v
 
 The deployments occur in the following order and are described in detail in the corresponding component directories
 
-1. [network](https://github.com/GoogleCloudPlatform/scientific-computing-examples/fluxfw-gcp/tf/examples/gpu/network)
-1. [iam](https://github.com/GoogleCloudPlatform/scientific-computing-examples/fluxfw-gcp/tf/examples/gpu/iam)
-1. [storage](https://github.com/GoogleCloudPlatform/scientific-computing-examples/fluxfw-gcp/tf/examples/gpu/storage)
-1. [cluster](https://github.com/GoogleCloudPlatform/scientific-computing-examples/fluxfw-gcp/tf/examples/gpu/cluster)
+1. [network](./network/README.md)
+1. [iam](./iam/README.md)
+1. [storage](./storage/README.md)
+1. [cluster](./cluster/README.md)

--- a/fluxfw-gcp/tf/examples/gpu/cluster/README.md
+++ b/fluxfw-gcp/tf/examples/gpu/cluster/README.md
@@ -46,3 +46,37 @@ terraform apply -var-file gpu.tfvars
 | region | The GCP region where the cluster resides | string | n/a | yes |
 | service_account_emails | A map with keys: 'compute', 'login', 'manager' that map to the service account to be used by the respective nodes | map(string) | n/a | yes |
 | subnetwork | Subnetwork to deploy to | string | n/a | yes |
+
+# Example Code
+
+Once the `terraform apply` command completes you can log into your cluster using the command:
+
+```bash
+gcloud compute ssh gpuex-login-001
+```
+
+While the cluster `manager` and `login` nodes are up the GPU compute node may take up to ten minutes to finish installing the NVIDIA drivers
+and runtime. Check the state of the compute node with the command:
+
+```bash
+flux resource list
+```
+
+When the compute node is ready you will see output that looks like:
+
+```bash
+     STATE PROPERTIES NNODES   NCORES    NGPUS NODELIST
+      free x86-64,e2       1        2        0 gpuex-login-001
+      free n1,x86-64       1        4        1 gpuex-compute-a-001
+ allocated                 0        0        0
+      down                 0        0        0
+```
+
+Once the compute node is ready you can allocate it with the command:
+
+```bash
+flux mini alloc -N1 -c4 -g1
+```
+
+Flux will allocate the node and give you a new shell on it. Now you can start working with the GPU attached to it. This 
+example will use the [Julia](http://julialang.org) programming language.

--- a/fluxfw-gcp/tf/examples/gpu/cluster/README.md
+++ b/fluxfw-gcp/tf/examples/gpu/cluster/README.md
@@ -49,6 +49,10 @@ terraform apply -var-file gpu.tfvars
 
 # Example Code
 
+## Setup
+
+### Node Allocation
+
 Once the `terraform apply` command completes you can log into your cluster using the command:
 
 ```bash
@@ -78,5 +82,210 @@ Once the compute node is ready you can allocate it with the command:
 flux mini alloc -N1 -c4 -g1
 ```
 
-Flux will allocate the node and give you a new shell on it. Now you can start working with the GPU attached to it. This 
-example will use the [Julia](http://julialang.org) programming language.
+Flux will allocate the node and give you a new shell on it. Now you can start working with the GPU attached to it. 
+
+### Julia
+
+This example will use the [Julia](http://julialang.org) programming language. Specifically designed for high performance computing, Julia
+features simple, yet powerful, support for NVIDIA's CUDA GPU programming platform. In the following steps you will install Julia in your
+home directory and add the necessary CUDA packages. Note, since your home directory is shared across all the nodes in the cluster you will
+only have to install Julia once.
+
+Download and install the latest [Julia version](https://julialang.org/downloads/) (currently v1.8.1) using these commands
+
+```bash
+curl -L https://julialang-s3.julialang.org/bin/linux/x64/1.8/julia-1.8.1-linux-x86_64.tar.gz --output julia-1.8.1-linux-x86_64.tar.gz
+tar xf julia-1.8.1-linux-x86_64.tar.gz
+
+mkdir ~/bin
+
+ln -s $PWD/julia-1.8.1/bin/julia ~/bin
+export PATH="~/bin:$PATH"
+```
+
+Bring up the Julia REPL with the command:
+
+```bash
+julia
+```
+
+```bash
+               _
+   _       _ _(_)_     |  Documentation: https://docs.julialang.org
+  (_)     | (_) (_)    |
+   _ _   _| |_  __ _   |  Type "?" for help, "]?" for Pkg help.
+  | | | | | | |/ _` |  |
+  | | |_| | | | (_| |  |  Version 1.8.1 (2022-09-06)
+ _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
+|__/                   |
+
+julia>
+```
+
+Enter the Julia package manager by pressing the `]` key and then add the CUDA package with the command:
+
+```julia
+(@v1.8) pkg> add CUDA
+```
+
+```julia
+  Installing known registries into `~/.julia`
+    Updating registry at `~/.julia/registries/General.toml`
+   Resolving package versions...
+... lots of package installation output ...
+        Info Packages marked with ⌅ have new versions available but cannot be upgraded. To see why use `status --outdated -m`
+Precompiling project...
+  34 dependencies successfully precompiled in 88 seconds
+```
+
+Exit the Julia package manager by pressing the `Backspace` key and verify your installation:
+
+```julia
+julia> using CUDA
+```
+```julia
+julia> CUDA.version()
+```
+```bash
+v"11.7.0"
+```
+```jula
+julia> CUDA.versioninfo()
+```
+```bash
+  Downloaded artifact: CUDA
+  Downloaded artifact: CUDA
+CUDA toolkit 11.7, artifact installation
+NVIDIA driver 515.65.1, for CUDA 11.7
+CUDA driver 11.7
+
+Libraries:
+- CUBLAS: 11.10.1
+- CURAND: 10.2.10
+- CUFFT: 10.7.2
+- CUSOLVER: 11.3.5
+- CUSPARSE: 11.7.3
+- CUPTI: 17.0.0
+- NVML: 11.0.0+515.65.1
+  Downloaded artifact: CUDNN
+- CUDNN: 8.30.2 (for CUDA 11.5.0)
+  Downloaded artifact: CUTENSOR
+- CUTENSOR: 1.4.0 (for CUDA 11.5.0)
+
+Toolchain:
+- Julia: 1.8.1
+- LLVM: 13.0.1
+- PTX ISA support: 3.2, 4.0, 4.1, 4.2, 4.3, 5.0, 6.0, 6.1, 6.3, 6.4, 6.5, 7.0, 7.1, 7.2
+- Device capability support: sm_35, sm_37, sm_50, sm_52, sm_53, sm_60, sm_61, sm_62, sm_70, sm_72, sm_75, sm_80, sm_86
+
+1 device:
+  0: Tesla V100-SXM2-16GB (sm_70, 15.779 GiB / 16.000 GiB available)
+```
+
+## SAXPY
+
+The _single-precision a*x + y_ (*SAXPY*) program is one of the _hello world_ codes for parallel programming. In this section
+you will run multiple versions of SAXPY that illustrate the range of Julia/GPU possibilities. Each of the codes you will run
+come from the excellent HPC.NRW [video](https://youtu.be/6pYUhi5zhPE) _Several Ways to SAXPY: Julia + CUDA.jl_.
+
+### Serial SAXPY
+
+As a base-line here is a simple serial version of SAXPY:
+
+```julia
+julia> const dim = 100_000_000;
+julia> const a = 3.1415;
+
+julia> x = ones(Float32, dim);
+julia> y = ones(Float32, dim);
+julia> z = zeros(Float32, dim);
+
+julia> z .= a .* x .+ y
+```
+
+This code uses Julia's [broadcasting](https://docs.julialang.org/en/v1/manual/arrays/#Broadcasting) mechanism to make even
+the serial version as simple and efficient as possible. To measure the runtime you can use the `@benchmark` macro from the
+`BenchmarkTools` package:
+
+```julia
+julia> using BenchmarkTools
+julia> @benchmark z .= a .* x .+ y
+```
+
+```bash
+BenchmarkTools.Trial: 49 samples with 1 evaluation.
+ Range (min … max):  101.848 ms … 105.649 ms  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     103.208 ms               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   103.256 ms ± 794.319 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+ Memory estimate: 128 bytes, allocs estimate: 4.
+```
+
+### CUArray SAXPY
+
+For array-based problems like SAXPY Julia provides `CUArrays` that behave like regular arrays except that their
+values reside on the GPU-device and operations on them take place in parallel on the GPU. The code is identical 
+to the serial version save for the CUDA annocations:
+
+```julia
+julia> x_d = CUDA.ones(Float32, dim);
+julia> y_d = CUDA.ones(Float32, dim);
+julia> z_d = CUDA.zeros(Float32, dim);
+
+julia> CUDA.@sync z_d .= a .* x_d .+ y_d
+```
+
+Note the use of the `CUDA.@sync` macro. By default code run on the GPU executes asynchronous. The `CUDA.@sync` macro tells Julia
+to wait for the GPU code to complete before continuing.
+
+Again, you can use the `@benchmark` macro to see how much faster, if any, the parallel code runs:
+
+```julia
+julia> @benchmark CUDA.@sync z_d .= a .* x_d .+ y_d
+```
+```bash
+BenchmarkTools.Trial: 2682 samples with 1 evaluation.
+ Range (min … max):  1.691 ms …  15.258 ms  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     1.827 ms               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   1.855 ms ± 271.584 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+ Memory estimate: 6.14 KiB, allocs estimate: 102.
+```
+
+Runtimes will vary but you can see that for large vectors the parallel version is significantly faster.
+
+### SAXPY Kernel Function
+
+While it is good practice to use the CUArray approach whenever possible Julia also makes it easy to write GPU _kernel fuctions_, 
+code that executes directly on the GPU-device. The details of writing GPU kernel functions are outside the scope of this tutorial.
+However, the following code shows how SAXPY would be written as a kernel function:
+
+```julia
+julia> function saxpy_gpu_kernel!(z,a,x,y)
+           i = (blockIdx().x - 1) * blockDim().x + threadIdx().x
+           if i <= length(z)
+               @inbounds z[i] = a * x[i] + y[i]
+           end
+           return nothing
+       end
+saxpy_gpu_kernel! (generic function with 1 method)
+```
+```julia
+julia> nthreads = CUDA.attribute(device(), CUDA.DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK);
+julia> nblocks = cld(dim, nthreads);
+julia> CUDA.@sync @cuda(threads=nthreads, blocks=nblocks, saxpy_gpu_kernel!(z_d,a,x_d,y_d))
+```
+
+Benchmarking the kernel shows only a marginal improvement over the CUArray.
+
+```julia
+julia> @benchmark CUDA.@sync @cuda(threads=nthreads, blocks=nblocks, saxpy_gpu_kernel!(z_d,a,x_d,y_d))
+```
+```bash
+BenchmarkTools.Trial: 2756 samples with 1 evaluation.
+ Range (min … max):  1.624 ms …   2.390 ms  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     1.800 ms               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   1.806 ms ± 101.343 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+ Memory estimate: 4.69 KiB, allocs estimate: 85.
+ ```

--- a/fluxfw-gcp/tf/examples/gpu/cluster/README.md
+++ b/fluxfw-gcp/tf/examples/gpu/cluster/README.md
@@ -289,3 +289,36 @@ BenchmarkTools.Trial: 2756 samples with 1 evaluation.
 
  Memory estimate: 4.69 KiB, allocs estimate: 85.
  ```
+### CUBLAS SAXPY
+
+The CUDA implementation of the _Basic Linear Algebra Subprograms_ (BLAS) package, CUBLAS, also provides an implementation
+of SAXPY. The Julia CUDA package wraps many of the libraries included in NVIDIAs CUDA toolkit and CUBLAS is one of them.
+So, in this last example you will call the CUBLAS `axpy!` function.
+
+```julia
+julia> using CUDA.CUBLAS
+julia> CUDA.@sync CUBLAS.axpy!(dim,a,x_d,y_d)
+```
+
+Note that unlike the other examples which returned the computed values in a separate vector the CUBLAS `axpy!` function
+modifies the `y` argument with the result of the computation. 
+
+Benchmarking the CUBLAS function may show a very small improvement over the SAXPY kernel fuction.
+
+```julia
+julia> @benchmark CUDA.@sync CUBLAS.axpy!(dim,a,x_d,y_d)
+```
+```bash
+BenchmarkTools.Trial: 2835 samples with 1 evaluation.
+ Range (min … max):  1.615 ms …  2.213 ms  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     1.742 ms              ┊ GC (median):    0.00%
+ Time  (mean ± σ):   1.756 ms ± 81.147 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+
+ Memory estimate: 2.98 KiB, allocs estimate: 49.
+```
+
+### Summary
+
+For _large_ inputs running even simple codes like SAXPY on a GPU can acheive significant speed ups. As demonstrated above
+Julia makes GPU programming very approachable. Of course there are CUDA libraries for other common HPC languages like FORTRAN,
+C/C++, and Python as well. You should choose the one that best fits your programming environment and skill set.

--- a/fluxfw-gcp/tf/examples/gpu/cluster/README.md
+++ b/fluxfw-gcp/tf/examples/gpu/cluster/README.md
@@ -1,0 +1,48 @@
+# Flux Framework Basic Example - Cluster Deployment
+
+This deployment uses the [Flux Framework Cluster Module]() to bring together the remote state from the other deployments
+in this example with the Flux Framework images built with Cloud Build to instantiate a cluster of Compute Engine instances
+with attached NVIDIA GPUs managed by the Flux Framework resource job management software.
+
+# Usage
+
+Initialize the deployment with the command:
+
+```bash
+terraform init
+```
+
+Make a copy of the `gpu.tfvars.example` file:
+
+```bash
+cp gpu.tfvars.example gpu.tfvars
+```
+
+Modify the gpu.tfvars to specify the desired configuration. For this example only one instance with 
+a single GPU attached is required. Feel free, however, to add additional nodes and/or additional GPUs
+up to your available quota.
+
+Note that many of the module variables receive their values from the remote state of other components.
+
+Deploy the cluster with the command:
+
+```bash
+terraform apply -var-file gpu.tfvars
+```
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| cluster_storage | A map with keys 'share' and 'mountpoint' describing an NFS export and its desired mount point | map(string) | n/a | yes |
+| compute_node_specs | A list of maps each with the keys: 'name_prefix', 'machin_arch', 'machine_type', and 'instances' which describe the compute node instances to create | list(maps(string)) | n/a | yes |
+| compute_scopes | The set of access scopes for compute node instances | set(string) | [ "cloud-platform" ] | yes |
+| login_node_specs | A list of maps each with the keys: 'name_prefix', 'machin_arch', 'machine_type', `gpu_count`, `gpu_type` and 'instances' which describe the login node instances to create | list(map(string)) | n/a | yes |
+| login_scopes | The set of access scopes for login node instances | set(string) | [ "cloud-platform" ] | yes |
+| manager_machine_type | The Compute Engine machine type to be used for the management node, not must be an x86_64 or AMD machine type | string | n/a | yes |
+| manager_name_prefix | The name prefix for the management node instance, the full instance name will be this prefix followed by node number | string | n/a | yes |
+| manager_scopes | The set of access scopes for management node instance | set(string) | [ "cloud-platform" ] | yes |
+| project_id | The GCP project ID | string | n/a | yes |
+| region | The GCP region where the cluster resides | string | n/a | yes |
+| service_account_emails | A map with keys: 'compute', 'login', 'manager' that map to the service account to be used by the respective nodes | map(string) | n/a | yes |
+| subnetwork | Subnetwork to deploy to | string | n/a | yes |

--- a/fluxfw-gcp/tf/examples/gpu/cluster/gpu.tfvars.example
+++ b/fluxfw-gcp/tf/examples/gpu/cluster/gpu.tfvars.example
@@ -1,0 +1,39 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+manager_machine_type = "e2-standard-8"
+manager_name_prefix  = "gpuex"
+manager_scopes       = [ "cloud-platform" ]
+
+login_node_specs = [
+    {
+        name_prefix  = "gpuex-login"
+        machine_arch = "x86-64"
+        machine_type = "e2-standard-4"
+        instances    = 1
+    },
+]
+login_scopes = [ "cloud-platform" ]
+
+compute_node_specs = [
+    {
+        name_prefix  = "gpuex-compute-a"
+        machine_arch = "x86-64"
+        machine_type = "n1-standard-8"
+        gpu_count    = 1
+        gpu_type     = "nvidia-tesla-v100"
+        instances    = 1
+    },
+]
+compute_scopes = [ "cloud-platform" ]

--- a/fluxfw-gcp/tf/examples/gpu/cluster/main.tf
+++ b/fluxfw-gcp/tf/examples/gpu/cluster/main.tf
@@ -1,0 +1,39 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module "cluster" {
+    source = "../../.."
+
+    project_id           = data.terraform_remote_state.network.outputs.subnet.project
+    region               = data.terraform_remote_state.network.outputs.subnet.region
+    
+    service_account_emails = {
+        manager = data.terraform_remote_state.iam.outputs.management_service_account
+        login   = data.terraform_remote_state.iam.outputs.login_service_account
+        compute = data.terraform_remote_state.iam.outputs.compute_service_account
+    }
+    
+    subnetwork           = data.terraform_remote_state.network.outputs.subnet.self_link
+    cluster_storage      = data.terraform_remote_state.storage.outputs.cluster_storage
+
+    manager_name_prefix  = var.manager_name_prefix
+    manager_machine_type = var.manager_machine_type
+    manager_scopes       = var.manager_scopes
+
+    login_node_specs     = var.login_node_specs
+    login_scopes         = var.login_scopes
+
+    compute_node_specs   = var.compute_node_specs
+    compute_scopes       = var.compute_scopes
+}

--- a/fluxfw-gcp/tf/examples/gpu/cluster/state.tf
+++ b/fluxfw-gcp/tf/examples/gpu/cluster/state.tf
@@ -1,0 +1,37 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "terraform_remote_state" "network" {
+    backend = "local"
+
+    config  = {
+        path = "../network/terraform.tfstate"
+    }
+}
+
+data "terraform_remote_state" "iam" {
+    backend = "local"
+
+    config  = {
+        path = "../iam/terraform.tfstate"
+    }
+}
+
+data "terraform_remote_state" "storage" {
+    backend = "local"
+
+    config  = {
+        path = "../storage/terraform.tfstate"
+    }
+}

--- a/fluxfw-gcp/tf/examples/gpu/cluster/variables.tf
+++ b/fluxfw-gcp/tf/examples/gpu/cluster/variables.tf
@@ -1,0 +1,41 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "compute_node_specs" {
+    type = list(map(string))
+}
+
+variable "compute_scopes" {
+    type = set(string)
+}
+
+variable "login_node_specs" {
+    type = list(map(string))
+}
+
+variable "login_scopes" {
+    type = set(string)
+}
+
+variable "manager_machine_type" {
+    type = string
+}
+
+variable "manager_name_prefix" {
+    type = string
+}
+
+variable "manager_scopes" {
+    type = set(string)
+}

--- a/fluxfw-gcp/tf/examples/gpu/iam/README.md
+++ b/fluxfw-gcp/tf/examples/gpu/iam/README.md
@@ -1,0 +1,42 @@
+# Flux Framework Basic Example - IAM Deployment
+
+This deployment creates the Cloud IAM service accounts for use by the Compute Engine cluster instances.
+Accounts are created, or assigned, to the compute, login, and management nodes.
+
+## Usage
+
+Execute all `terraform` commands from the `iam/` directory. 
+
+- Use the `-chdir=` flag to select the desired iam deployment 
+- Use the `-state=` flag to save Terraform state in the `iam/` directory for use by other components in the system. 
+
+This component depends on the state of the [network]() component for the correct values of its project field.
+
+[Note: a production deployment would use a GCS bucket to manage remote state]
+
+Choose one of the iam options below and execute the associated commands to deploy the selected service accounts
+
+### Default
+
+This version of the component simply uses the same service account, the default compute service account, for each of the
+cluster node types.
+
+Initialize the component with the command:
+
+```bash
+terraform -chdir=default init
+```
+
+Deploy the service accounts with the command:
+
+```bash
+terraform -chdir=default apply -state=$PWD/terraform.tfstate
+```
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| compute_service_account | The service account for use by compute nodes |
+| login_service_account | The service account for use by login nodes |
+| management_service_account | The service account for use by management nodes |

--- a/fluxfw-gcp/tf/examples/gpu/iam/default/main.tf
+++ b/fluxfw-gcp/tf/examples/gpu/iam/default/main.tf
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_compute_default_service_account" "default" {
+    project = data.terraform_remote_state.network.outputs.subnet.project
+}

--- a/fluxfw-gcp/tf/examples/gpu/iam/default/outputs.tf
+++ b/fluxfw-gcp/tf/examples/gpu/iam/default/outputs.tf
@@ -1,0 +1,25 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "compute_service_account" {
+    value = data.google_compute_default_service_account.default.email
+}
+
+output "login_service_account" {
+    value = data.google_compute_default_service_account.default.email
+}
+
+output "management_service_account" {
+    value = data.google_compute_default_service_account.default.email
+}

--- a/fluxfw-gcp/tf/examples/gpu/iam/default/state.tf
+++ b/fluxfw-gcp/tf/examples/gpu/iam/default/state.tf
@@ -1,0 +1,21 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "terraform_remote_state" "network" {
+    backend = "local"
+
+    config  = {
+        path = "../../network/terraform.tfstate"
+    }
+}

--- a/fluxfw-gcp/tf/examples/gpu/network/README.md
+++ b/fluxfw-gcp/tf/examples/gpu/network/README.md
@@ -1,0 +1,74 @@
+# Flux Framework Basic Example - Network Deployment
+
+This deployment creates a GCP network for use by one or more clusters of Compute Engine instances
+composed into an HPC system using the Flux Framework resource job management software.
+
+## Usage
+
+Execute all `terraform` commands from the `network/` directory. 
+
+- Use the `-chdir=` flag to select the desired network deployment 
+- Use the `-state=` flag to save Terraform state in the `network/` directory for use by other components in the system. 
+
+[Note: a production deployment would use a GCS bucket to manage remote state]
+
+Choose one of the network options below and execute the associated commands to deploy the selected network
+
+### Default
+
+This option uses your project's `default` network. It is the simplest option since it uses existing resources and
+therefore is quick to deploy. However, because the cluster nodes deploy without external IP addresses, they will not
+be able to access external resources using this network option.
+
+#### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| project_id | The GCP project ID | string | n/a | yes |
+| region | The GCP region where the network resides | string | n/a | yes |
+| subnet_name | Name of the subnetwork to deploy | string | default | no |
+
+Initialize the component with the command:
+
+```bash
+terraform -chdir=default init
+```
+
+Deploy the network with the command:
+
+```bash
+terraform -chdir=default apply -var project_id=<project_id> -var region=<region> -state=$PWD/terraform.tfstate
+```
+
+### Zonal
+
+This option creates a new VPC Network for your cluster. The network includes a NAT so that cluster nodes can access
+external resources and the firewall rules necessary to enable inter-node communication.
+
+#### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| network_name | Name of the VPC network | string | n/a | yes |
+| project_id | The GCP project ID | string | n/a | yes |
+| region | The GCP region where the network resides | string | n/a | yes |
+| ssh_source_ranges | List of CIDR ranges from which SSH connections are accepted | list(string) | ["0.0.0.0/0"] | no |
+| subnet_ip | CIDR for the network subnet | string | "10.10.0.0./18" | no |
+
+Initialize the component with the command:
+
+```bash
+terraform -chdir=zonal init
+```
+
+Deploy the network with the command:
+
+```bash
+terraform -chdir=zonal apply -var project_id=<project_id> -var region=<region> -var network_name=<network_name> -state=$PWD/terraform.tfstate
+```
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| subnet | A map structure with keys: project, region, network, and self_link |

--- a/fluxfw-gcp/tf/examples/gpu/network/default/main.tf
+++ b/fluxfw-gcp/tf/examples/gpu/network/default/main.tf
@@ -1,0 +1,19 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_compute_subnetwork" "subnet" {
+    project = var.project_id
+    region  = var.region
+    name    = var.subnet_name
+}

--- a/fluxfw-gcp/tf/examples/gpu/network/default/outputs.tf
+++ b/fluxfw-gcp/tf/examples/gpu/network/default/outputs.tf
@@ -1,0 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "subnet" {
+    value = data.google_compute_subnetwork.subnet
+}

--- a/fluxfw-gcp/tf/examples/gpu/network/default/variables.tf
+++ b/fluxfw-gcp/tf/examples/gpu/network/default/variables.tf
@@ -1,0 +1,29 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+    description = "The GCP project ID"
+    type        = string
+}
+
+variable "region" {
+    description = "The GCP region where the network resides"
+    type        = string
+}
+
+variable "subnet_name" {
+    description = "Name of the subnetwork to deploy"
+    type        = string
+    default     = "default"
+}

--- a/fluxfw-gcp/tf/examples/gpu/network/zonal/main.tf
+++ b/fluxfw-gcp/tf/examples/gpu/network/zonal/main.tf
@@ -1,0 +1,93 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module "network" {
+  source       = "github.com/terraform-google-modules/terraform-google-network"
+  project_id   = var.project_id
+  network_name = var.network_name
+  subnets      = [
+    {
+      subnet_name   = "${var.network_name}-subnet-01"
+      subnet_ip     = var.subnet_ip
+      subnet_region = var.region
+    }
+  ]
+}
+
+module "nat" {
+  source        = "github.com/terraform-google-modules/terraform-google-cloud-nat"
+  project_id    = var.project_id
+  region        = var.region
+  network       = module.network.network_name
+  create_router = true
+  router        = "${module.network.network_name}-router"
+}
+
+module "firewall" {
+  source          = "github.com/terraform-google-modules/terraform-google-network/modules/firewall-rules"
+  project_id      = var.project_id
+  network_name    = module.network.network_name
+  rules           = [
+    {
+      name                    = "${var.network_name}-allow-ssh"
+      direction               = "INGRESS"
+      priority                = null
+      description             = null
+      ranges                  = ["0.0.0.0/0"]
+      source_tags             = null
+      source_service_accounts = null
+      target_tags             = ["flux"]
+      target_service_accounts = null
+      allow                   = [
+        {
+          protocol = "tcp"
+          ports    = ["22"]
+        }
+      ],
+      deny                    = []
+      log_config              = {
+        metadata = "INCLUDE_ALL_METADATA"
+      }
+    },
+    {
+      name                    = "${var.network_name}-allow-interal-traffic"
+      direction               = "INGRESS"
+      priority                = null
+      description             = null
+      ranges                  = ["0.0.0.0/0"]
+      source_tags             = null
+      source_service_accounts = null
+      target_tags             = ["ssh", "flux"]
+      target_service_accounts = null
+      allow                   = [
+        {
+          protocol = "icmp"
+          ports    = []
+        },
+        {
+          protocol = "udp"
+          ports    = ["0-65535"]
+        },
+        {
+          protocol = "tcp"
+          ports    = ["0-65535"]
+        }
+      ]
+      deny                    = []
+      log_config              = {
+        metadata = "INCLUDE_ALL_METADATA"
+      }
+    }
+  ]
+}

--- a/fluxfw-gcp/tf/examples/gpu/network/zonal/outputs.tf
+++ b/fluxfw-gcp/tf/examples/gpu/network/zonal/outputs.tf
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "subnet" {
+    value = { 
+        project = module.network.subnets["${var.region}/${module.network.subnets_names[0]}"].project,
+        region  = var.region,
+        network = module.network.network
+        self_link = module.network.subnets_self_links[0]
+    }
+}

--- a/fluxfw-gcp/tf/examples/gpu/network/zonal/variables.tf
+++ b/fluxfw-gcp/tf/examples/gpu/network/zonal/variables.tf
@@ -1,0 +1,40 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "network_name" {
+    description = "Name of the VPC network"
+    type        = string
+}
+
+variable "project_id" {
+    description = "The GCP project ID"
+    type        = string
+}
+
+variable "region" {
+    description = "The GCP region where the network resides"
+    type        = string
+}
+
+variable "ssh_source_ranges" {
+    description = "List of CIDR ranges from which SSH connections are accepted"
+    type        = list(string)
+    default     = ["0.0.0.0/0"]
+}
+
+variable "subnet_ip" {
+    description = "CIDR for the network subnet"
+    type        = string
+    default     = "10.10.0.0/18"
+}

--- a/fluxfw-gcp/tf/examples/gpu/storage/README.md
+++ b/fluxfw-gcp/tf/examples/gpu/storage/README.md
@@ -1,0 +1,53 @@
+# Flux Framework Basic Example - Storage Deployment
+
+This deployment creates a share /home directory for the cluster nodes and exports it via NFS.
+
+TODO: support the ability to create additional shared directories for other purposes, e.g., Spack installs
+TODO: support the creation of other storage models, e.g., parallel filesystems and/or object storeage
+
+## Usage
+
+Execute all `terraform` commands from the `storage/` directory. 
+
+- Use the `-chdir=` flag to select the desired storage deployment 
+- Use the `-state=` flag to save Terraform state in the `storage/` directory for use by other components in the system. 
+
+This component depends on the state of the [network]() component for the correct values of its project field.
+
+[Note: a production deployment would use a GCS bucket to manage remote state]
+
+Choose one of the storage options below and execute the associated commands to deploy the selected storage provider
+
+### Filestore
+
+This version of the component creates a Cloud Filestore instance that exports a directory named /home. Each cluster node
+will mount this directory over its own /home directory at boot time.
+
+#### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| name | The filestore instance name | string | n/a | yes |
+| share_name | Name of the directory being shared | string | n/a | yes |
+| tier | The Cloud Filestore TIER to configure | string | STANDARD | no |
+
+Initialize the component with the command:
+
+```bash
+terraform -chdir=filestore init
+```
+
+Deploy the storage with the command:
+
+```bash
+terraform -chdir=filestore apply -var name=fluxstore -var share_name=home -state $PWD/terraform.tfstate
+```
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| cluster_storage | A map with keys: 'share' and 'mountpoint' whose values are the IP address/directory of the NFS export and the intended cluster node mountpoint |
+
+| Name | Description |
+|------|-------------|

--- a/fluxfw-gcp/tf/examples/gpu/storage/filestore/main.tf
+++ b/fluxfw-gcp/tf/examples/gpu/storage/filestore/main.tf
@@ -1,0 +1,37 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_compute_zones" "available" {
+    project = data.terraform_remote_state.network.outputs.subnet.project
+    region  = data.terraform_remote_state.network.outputs.subnet.region
+}
+
+resource "google_filestore_instance" "instance" {
+    project     = data.terraform_remote_state.network.outputs.subnet.project
+    provider    = google-beta
+    location    = data.google_compute_zones.available.names[0]
+
+    name        = var.name
+    tier        = var.tier
+    
+    file_shares {
+        name        = var.share_name
+        capacity_gb = 1024
+    }
+    
+    networks {
+        network = data.terraform_remote_state.network.outputs.subnet.network.network_name
+        modes   = ["MODE_IPV4"]
+    }
+}

--- a/fluxfw-gcp/tf/examples/gpu/storage/filestore/outputs.tf
+++ b/fluxfw-gcp/tf/examples/gpu/storage/filestore/outputs.tf
@@ -1,0 +1,20 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "cluster_storage" {
+    value = {
+        share = "${resource.google_filestore_instance.instance.networks[0].ip_addresses[0]}:/${var.share_name}",
+        mountpoint = "/${var.share_name}"
+    }
+}

--- a/fluxfw-gcp/tf/examples/gpu/storage/filestore/state.tf
+++ b/fluxfw-gcp/tf/examples/gpu/storage/filestore/state.tf
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "terraform_remote_state" "network" {
+    backend = "local"
+
+    config  = {
+        path = "../../network/terraform.tfstate"
+    }
+}
+

--- a/fluxfw-gcp/tf/examples/gpu/storage/filestore/variables.tf
+++ b/fluxfw-gcp/tf/examples/gpu/storage/filestore/variables.tf
@@ -1,0 +1,29 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "name" {
+    description = "The filestore instance name"
+    type        = string
+}
+
+variable "share_name" {
+    description = "Name of the directory being shared"
+    type        = string
+}
+
+variable "tier" {
+    description = "The Cloud Filestore TIER to configure"
+    type        = string
+    default     = "STANDARD"
+}


### PR DESCRIPTION
This pull request adds an example that illustrates how to create a flux cluster with GPU-attached compute nodes.

The component structure, network, iam, storage is identical to the basic flux example. The cluster is different in that
it includes a compute_node_spec that specifies GPU nodes.

The README demonstrates how to use the GPU-attached compute node via flux and includes a SAXPY-based 
mini-tutorial on GPU programming with Julia.