### PR TITLE
Update flux-core to v0.46.1

### DIFF
--- a/fluxfw-gcp/img/flux-compute-builder-startup-script.m4
+++ b/fluxfw-gcp/img/flux-compute-builder-startup-script.m4
@@ -31,7 +31,7 @@ useradd -M -r -s /bin/false -c "flux-framework identity" flux
 
 cd /usr/share
 
-git clone -b v0.44.0 https://github.com/flux-framework/flux-core.git
+git clone -b v0.46.1 https://github.com/flux-framework/flux-core.git
 git clone -b v0.25.0 https://github.com/flux-framework/flux-sched.git
 git clone -b v0.8.0 https://github.com/flux-framework/flux-security.git
 

--- a/fluxfw-gcp/img/flux-login-builder-startup-script.m4
+++ b/fluxfw-gcp/img/flux-login-builder-startup-script.m4
@@ -29,7 +29,7 @@ useradd -M -r -s /bin/false -c "flux-framework identity" flux
 
 cd /usr/share
 
-git clone -b v0.44.0 https://github.com/flux-framework/flux-core.git
+git clone -b v0.46.1 https://github.com/flux-framework/flux-core.git
 git clone -b v0.25.0 https://github.com/flux-framework/flux-sched.git
 git clone -b v0.8.0 https://github.com/flux-framework/flux-security.git
 

--- a/fluxfw-gcp/img/flux-manager-builder-startup-script.sh
+++ b/fluxfw-gcp/img/flux-manager-builder-startup-script.sh
@@ -57,7 +57,7 @@ useradd -M -r -s /bin/false -c "flux-framework identity" flux
 
 cd /usr/share
 
-git clone -b v0.44.0 https://github.com/flux-framework/flux-core.git
+git clone -b v0.46.1 https://github.com/flux-framework/flux-core.git
 git clone -b v0.25.0 https://github.com/flux-framework/flux-sched.git
 git clone -b v0.8.0 https://github.com/flux-framework/flux-security.git
 


### PR DESCRIPTION
This pull request updates the version of flux-core used to build the flux images to v0.46.1. The release notes for flux-core v0.46.1 are [here](https://github.com/flux-framework/flux-core/blob/v0.46.1/NEWS.md)