### PR TITLE
Install podman and apptainer on login and compute nodes

### DIFF
--- a/fluxfw-gcp/img/flux-compute-builder-startup-script.m4
+++ b/fluxfw-gcp/img/flux-compute-builder-startup-script.m4
@@ -26,6 +26,7 @@ dnf install -y \
 include(packages.txt)dnl
 
 ifdef(`X86_64', `include(nvidia_downloads.txt)')dnl
+ifdef(`X86_64', `include(install_apptainer.txt)')dnl
 
 useradd -M -r -s /bin/false -c "flux-framework identity" flux
 

--- a/fluxfw-gcp/img/flux-login-builder-startup-script.m4
+++ b/fluxfw-gcp/img/flux-login-builder-startup-script.m4
@@ -25,6 +25,9 @@ dnf install -y epel-release
 dnf install -y \
 include(packages.txt)dnl
 
+include(install_apptainer.txt)dnl
+dnf install -y podman
+
 useradd -M -r -s /bin/false -c "flux-framework identity" flux
 
 cd /usr/share

--- a/fluxfw-gcp/img/install_apptainer.txt
+++ b/fluxfw-gcp/img/install_apptainer.txt
@@ -1,0 +1,4 @@
+APPTAINER_ASSETS=$(curl -s https://api.github.com/repos/apptainer/apptainer/releases/latest | jq '.[] | match(".*assets$"; "g") | .string' 2>/dev/null | tr -d '"')
+APPTAINER_RPM=$(curl -s ${APPTAINER_ASSETS} | jq '.[] | .browser_download_url' | egrep .*apptainer-[[:digit:]].*x86_64 | tr -d '"')
+
+dnf install -y ${APPTAINER_RPM}


### PR DESCRIPTION
This pull request fixes #38 

It installs the latest version of [Apptainer](http://apptainer.org/) on the login node(s) and on any x86_64 nodes in the cluster. It also installs [Podman](https://podman.io/) on the login node. Doing so prepares GCP flux clusters for the best practices to be codified in this [bug](https://b.corp.google.com/issues/266558558).