### PR TITLE
add support for image family

### DIFF
--- a/fluxfw-gcp/tf/main.tf
+++ b/fluxfw-gcp/tf/main.tf
@@ -15,6 +15,7 @@
 module "management_node" {
     source             = "./modules/management"
     name_prefix        = var.manager_name_prefix
+    family             = var.manager_family  
     
     project_id         = var.project_id
     region             = var.region
@@ -44,6 +45,8 @@ module "login_nodes" {
     region          = var.region
 
     name_prefix     = each.value.name_prefix
+    family          = var.login_family
+
     subnetwork      = var.subnetwork
     machine_arch    = each.value.machine_arch
     machine_type    = each.value.machine_type
@@ -69,6 +72,9 @@ module "compute_nodes" {
     project_id        = var.project_id
     region            = var.region
 
+    family            = var.compute_family
+    arm_family        = var.compute_arm_family
+    
     name_prefix       = each.value.name_prefix
     subnetwork        = var.subnetwork
     machine_arch      = each.value.machine_arch

--- a/fluxfw-gcp/tf/modules/compute/main.tf
+++ b/fluxfw-gcp/tf/modules/compute/main.tf
@@ -14,12 +14,12 @@
 
 data "google_compute_image" "fluxfw_compute_arm64_image" {
     project = var.project_id
-    family  = "flux-fw-compute-arm64"
+    family  = var.arm_family
 }
 
 data "google_compute_image" "fluxfw_compute_x86_64_image" {
     project = var.project_id
-    family  = "flux-fw-compute-x86-64"
+    family  = var.family
 }
 
 data "google_compute_zones" "available" {

--- a/fluxfw-gcp/tf/modules/compute/variables.tf
+++ b/fluxfw-gcp/tf/modules/compute/variables.tf
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+variable "arm_family" {
+    description = "The source arm image family prefix to use"
+    type        = string
+    default     = "flux-fw-compute-arm64"
+}
+
 variable "automatic_restart" {
   type        = bool
   description = "(Optional) Specifies whether the instance should be automatically restarted if it is terminated by Compute Engine (not terminated by a user)."
@@ -28,6 +34,12 @@ variable "compact_placement" {
     description = "(Optional) a boolean which determines whether a set of compute nodes has a compact placement resource policy attached to them."
     type        = bool
     default     = false
+}
+
+variable "family" {
+    description = "The source X86 image family prefix to use"
+    type        = string
+    default     = "flux-fw-compute-x86-64"
 }
 
 variable "gpu" {

--- a/fluxfw-gcp/tf/modules/login/main.tf
+++ b/fluxfw-gcp/tf/modules/login/main.tf
@@ -14,7 +14,7 @@
 
 data "google_compute_image" "fluxfw_login_x86_64_image" {
     project = var.project_id
-    family  = "flux-fw-login-x86-64"
+    family  = var.family
 }
 
 data "google_compute_zones" "available" {

--- a/fluxfw-gcp/tf/modules/login/variables.tf
+++ b/fluxfw-gcp/tf/modules/login/variables.tf
@@ -18,6 +18,12 @@ variable "boot_script" {
     default     = null
 }
 
+variable "family" {
+    description = "The source image family prefix to use"
+    type        = string
+    default     = "flux-fw-login-x86-64"
+}
+
 variable "machine_arch" {
     description = "The instruction set architecture, ARM64 or x86_64, used by the login node"
     type        = string

--- a/fluxfw-gcp/tf/modules/management/main.tf
+++ b/fluxfw-gcp/tf/modules/management/main.tf
@@ -14,7 +14,7 @@
 
 data "google_compute_image" "fluxfw_manager_image" {
     project = var.project_id
-    family  = "flux-fw-manager"
+    family  = var.family
 }
 
 module "flux_manager_instance_template" {

--- a/fluxfw-gcp/tf/modules/management/variables.tf
+++ b/fluxfw-gcp/tf/modules/management/variables.tf
@@ -17,6 +17,12 @@ variable "compute_node_specs" {
     type        = string
 }
 
+variable "family" {
+    description = "The source image family prefix to use"
+    type        = string
+    default     = "flux-fw-manager"
+}
+
 variable "login_node_specs" {
     description = "A JSON encoded list of maps each with the keys: 'name_prefix', 'machin_arch', 'machine_type', and 'instances' which describe the login node instances to create"
     type        = string

--- a/fluxfw-gcp/tf/variables.tf
+++ b/fluxfw-gcp/tf/variables.tf
@@ -17,6 +17,18 @@ variable "cluster_storage" {
     type        = map(string)
 }
 
+variable "compute_arm_family" {
+    description = "The source arm image family prefix to be used by the compute node(s)"
+    type        = string
+    default     = "flux-fw-compute-arm64"
+}
+
+variable "compute_family" {
+    description = "The source image x86 prefix to be used by the compute node(s)"
+    type        = string
+    default     = "flux-fw-compute-x86-64"
+}
+
 variable "compute_node_specs" {
     description = "A list of compute node specifications"
     type = list(object({
@@ -39,6 +51,14 @@ variable "compute_scopes" {
     type        = set(string)
 }
 
+
+variable "login_family" {
+    description = "The source image prefix to be used by the login node"
+    type        = string
+    default     = "flux-fw-login-x86-64"
+}
+
+
 variable "login_node_specs" {
     description = "A list of login node specifications"
     type = list(object({
@@ -56,6 +76,12 @@ variable "login_scopes" {
     description = "The set of access scopes for login node instances"
     default     = [ "cloud-platform" ]
     type = set(string)
+}
+
+variable "manager_family" {
+    description = "The source image prefix to be used by the manager"
+    type        = string
+    default     = "flux-fw-manager"
 }
 
 variable "manager_machine_type" {


### PR DESCRIPTION
I ran into an issue today where Cloud Build was... having a moment?

![image](https://github.com/GoogleCloudPlatform/scientific-computing-examples/assets/814322/9b1ac9b1-1fb9-437b-a369-4528d906871c)

I really needed to enable cgroups v2 to the images (I couldn't do it as a startup script [because reasons](https://twitter.com/jasonmstover/status/1660342910347358216), and I needed cgroups v2 because I wanted to test [k3s in rootless mode](https://docs.k3s.io/advanced#running-rootless-servers-experimental). I was bummed that cloud build wasn't working, but realized that I could instantiate previously built images, do the change to the grub config, and then save as a machine image. The steps looked like this:

1. Went to Compute Engine -> Images
2. Create an instance from each
3. Install cgroups v2 (instructions below)
4. Stop the instances
5. Under Compute Engine -> Image "Create an Image"
6. Create each one from Source Disk from the image Don't forget to use the same prefix for the family (e.g., flux-cgroups-manager-x86-052123 has family flux-cgroups-manager).

Note it's important to set the family for the images as this is how they are selected here. Also note that a machine image is NOT the same as just an image in compute engine (I made this mistake first, oops).

Here are the instructions I used to enable cgroups 2. Note that since I login as my user, sudo is needed. If this is in a root run start script, you likely wouldn't need it.

```bash
# This is what I ran manually to update the machines and save new images
sudo dnf install -y grubby 
sudo grubby --update-kernel=ALL --args="systemd.unified_cgroup_hierarchy=1"

sudo mkdir -p /etc/systemd/system/user@.service.d
cat <<EOF | sudo tee /etc/systemd/system/user@.service.d/delegate.conf
[Service]
Delegate=cpu cpuset io memory pids
EOF
sudo systemctl daemon-reload
```

And then I was able to update the family to be the families I defined here (allowed by the content of this PR) and create the cluster and verify that cgroups 2 is enabled (this was on the login node):

```
cat /sys/fs/cgroup/cgroup.controllers
cpuset cpu io memory hugetlb pids rdma
```

I was able to get k3s (master / control plane) running and am still working on the worker nodes, but I've gotten far enough with this change to open this PR! Feel free to disregard / not add, because it's probably a rare use case to want to modify the family, but I am finding it essential today.

ping @wkharold 

## TLDR

Problem: the user wants to use a custom image family, and currently the families are hard coded.
Solution: add the family name as a variable.