### PR TITLE
expose os login as a variable

### DIFF
--- a/fluxfw-gcp/tf/main.tf
+++ b/fluxfw-gcp/tf/main.tf
@@ -15,6 +15,7 @@
 module "management_node" {
     source             = "./modules/management"
     name_prefix        = var.manager_name_prefix
+    enable_os_login    = var.enable_os_login
     family             = var.manager_family  
     
     project_id         = var.project_id
@@ -45,6 +46,7 @@ module "login_nodes" {
     region          = var.region
 
     name_prefix     = each.value.name_prefix
+    enable_os_login = var.enable_os_login
     family          = var.login_family
 
     subnetwork      = var.subnetwork
@@ -73,6 +75,7 @@ module "compute_nodes" {
     region            = var.region
 
     family            = var.compute_family
+    enable_os_login   = var.enable_os_login
     arm_family        = var.compute_arm_family
     
     name_prefix       = each.value.name_prefix

--- a/fluxfw-gcp/tf/modules/compute/main.tf
+++ b/fluxfw-gcp/tf/modules/compute/main.tf
@@ -72,7 +72,7 @@ module "flux_compute_instance_template" {
     metadata             = { 
         "boot-script"      : var.boot_script
         "login-node-specs" : var.login_node_specs
-        "enable-oslogin"   : "TRUE",
+        "enable-oslogin"   : var.enable_os_login,
         "flux-manager"     : "${var.manager}",
         "VmDnsSetting"     : "GlobalDefault",
         "nfs-mounts"       : jsonencode(var.nfs_mounts),

--- a/fluxfw-gcp/tf/modules/compute/variables.tf
+++ b/fluxfw-gcp/tf/modules/compute/variables.tf
@@ -36,6 +36,12 @@ variable "compact_placement" {
     default     = false
 }
 
+variable "enable_os_login" {
+    description = "Use OS Login to determine username for uid/gid"
+    type        = string
+    default     = "TRUE"
+}
+
 variable "family" {
     description = "The source X86 image family prefix to use"
     type        = string

--- a/fluxfw-gcp/tf/modules/login/main.tf
+++ b/fluxfw-gcp/tf/modules/login/main.tf
@@ -45,7 +45,7 @@ module "flux_login_instance_template" {
     source_image_project = local.login_images["${var.machine_arch}"].project
     metadata             = { 
         "boot-script"    : var.boot_script
-        "enable-oslogin" : "TRUE",
+        "enable-oslogin" : var.enable_os_login,
         "flux-manager"   : "${var.manager}",
         "VmDnsSetting"   : "GlobalDefault",
         "nfs-mounts"     : jsonencode(var.nfs_mounts),

--- a/fluxfw-gcp/tf/modules/login/variables.tf
+++ b/fluxfw-gcp/tf/modules/login/variables.tf
@@ -24,6 +24,12 @@ variable "family" {
     default     = "flux-fw-login-x86-64"
 }
 
+variable "enable_os_login" {
+    description = "Use OS Login to determine username for uid/gid"
+    type        = string
+    default     = "TRUE"
+}
+
 variable "machine_arch" {
     description = "The instruction set architecture, ARM64 or x86_64, used by the login node"
     type        = string

--- a/fluxfw-gcp/tf/modules/management/main.tf
+++ b/fluxfw-gcp/tf/modules/management/main.tf
@@ -30,7 +30,7 @@ module "flux_manager_instance_template" {
     source_image         = data.google_compute_image.fluxfw_manager_image.self_link
     source_image_project = data.google_compute_image.fluxfw_manager_image.project
     metadata             = {
-        "enable-oslogin"     : "TRUE",
+        "enable-oslogin"     : var.enable_os_login,
         "VmDnsSetting"       : "GlobalDefault"
         "nfs-mounts"         : jsonencode(var.nfs_mounts)
         "compute-node-specs" : var.compute_node_specs

--- a/fluxfw-gcp/tf/modules/management/variables.tf
+++ b/fluxfw-gcp/tf/modules/management/variables.tf
@@ -17,6 +17,12 @@ variable "compute_node_specs" {
     type        = string
 }
 
+variable "enable_os_login" {
+    description = "Use OS Login to determine username for uid/gid"
+    type        = string
+    default     = "TRUE"
+}
+
 variable "family" {
     description = "The source image family prefix to use"
     type        = string

--- a/fluxfw-gcp/tf/variables.tf
+++ b/fluxfw-gcp/tf/variables.tf
@@ -29,18 +29,26 @@ variable "compute_family" {
     default     = "flux-fw-compute-x86-64"
 }
 
+# This is directed to the manager, which doesn't have a spec block
+variable "enable_os_login" {
+    description = "Use OS Login to determine username for uid/gid"
+    type        = string
+    default     = "TRUE"
+}
+
 variable "compute_node_specs" {
     description = "A list of compute node specifications"
     type = list(object({
-       name_prefix  = string
-       machine_arch = string
-       machine_type = string
-       gpu_type     = string
-       gpu_count    = number
-       compact      = bool
-       instances    = number
-       properties   = set(string)
-       boot_script  = string
+       name_prefix     = string
+       machine_arch    = string
+       machine_type    = string
+       gpu_type        = string
+       gpu_count       = number
+       compact         = bool
+       instances       = number
+       properties      = set(string)
+       boot_script     = string
+       enable_os_login = string
     }))
     default = []
 }
@@ -62,12 +70,13 @@ variable "login_family" {
 variable "login_node_specs" {
     description = "A list of login node specifications"
     type = list(object({
-       name_prefix  = string
-       machine_arch = string
-       machine_type = string
-       instances    = number
-       properties   = set(string)
-       boot_script  = string
+       name_prefix     = string
+       machine_arch    = string
+       machine_type    = string
+       instances       = number
+       properties      = set(string)
+       boot_script     = string
+       enable_os_login = string
     }))
     default = []
 }


### PR DESCRIPTION
This will address one part of #56 to expose the enabling of os login. The one design choice that we might want to consider is to scope the "global" "enable_os_login" to be for the manager, since it seems like the others come from the compute/login node specs. Another question I'm curious about is why this particular variable is a string "TRUE" instead of a boolean?

But @wkharold we need to do a bit more debugging before this is good to go - I'm not allowed to login anymore.

```
$ gcloud compute ssh gffw-login-001 --zone us-central1-a
External IP address was not found; defaulting to using IAP tunneling.
WARNING: 

To increase the performance of the tunnel, consider installing NumPy. For instructions,
please see https://cloud.google.com/iap/docs/using-tcp-forwarding#increasing_the_tcp_upload_bandwidth

myusername@compute.5038866934849735751: Permission denied (publickey,gssapi-keyex,gssapi-with-mic).

Recommendation: To check for possible causes of SSH connectivity issues and get
recommendations, rerun the ssh command with the --troubleshoot option.

gcloud compute ssh gffw-login-001 --project=llnl-flux --zone=us-central1-a --troubleshoot

Or, to investigate an IAP tunneling issue:

gcloud compute ssh gffw-login-001 --project=llnl-flux --zone=us-central1-a --troubleshoot --tunnel-through-iap

ERROR: (gcloud.compute.ssh) [/usr/bin/ssh] exited with return code [255].
```
Let me know your thoughts! We basically need the username that shows up in the gid/uid maps to be the same. I don't care what it is.