### PR TITLE
Add version constraints to all CFT module usage

### DIFF
--- a/fluxfw-gcp/tf/examples/foundation/network/zonal/main.tf
+++ b/fluxfw-gcp/tf/examples/foundation/network/zonal/main.tf
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 module "network" {
-  source       = "github.com/terraform-google-modules/terraform-google-network"
+  source  = "terraform-google-modules/network/google"
+  version = "~> 9.0"
+
   project_id   = var.project_id
   network_name = var.network_name
-  subnets      = [
+  subnets = [
     {
       subnet_name   = "${var.network_name}-subnet-01"
       subnet_ip     = var.subnet_ip
@@ -26,7 +28,9 @@ module "network" {
 }
 
 module "nat" {
-  source        = "github.com/terraform-google-modules/terraform-google-cloud-nat"
+  source  = "terraform-google-modules/cloud-nat/google"
+  version = "~> 5.0"
+
   project_id    = var.project_id
   region        = var.region
   network       = module.network.network_name
@@ -35,10 +39,12 @@ module "nat" {
 }
 
 module "firewall" {
-  source          = "github.com/terraform-google-modules/terraform-google-network/modules/firewall-rules"
-  project_id      = var.project_id
-  network_name    = module.network.network_name
-  rules           = [
+  source  = "terraform-google-modules/network/google//modules/firewall-rules"
+  version = "~> 9.0"
+
+  project_id   = var.project_id
+  network_name = module.network.network_name
+  rules = [
     {
       name                    = "${var.network_name}-allow-ssh"
       direction               = "INGRESS"
@@ -49,14 +55,14 @@ module "firewall" {
       source_service_accounts = null
       target_tags             = ["flux"]
       target_service_accounts = null
-      allow                   = [
+      allow = [
         {
           protocol = "tcp"
           ports    = ["22"]
         }
       ],
-      deny                    = []
-      log_config              = {
+      deny = []
+      log_config = {
         metadata = "INCLUDE_ALL_METADATA"
       }
     },
@@ -70,7 +76,7 @@ module "firewall" {
       source_service_accounts = null
       target_tags             = ["ssh", "flux"]
       target_service_accounts = null
-      allow                   = [
+      allow = [
         {
           protocol = "icmp"
           ports    = []
@@ -84,8 +90,8 @@ module "firewall" {
           ports    = ["0-65535"]
         }
       ]
-      deny                    = []
-      log_config              = {
+      deny = []
+      log_config = {
         metadata = "INCLUDE_ALL_METADATA"
       }
     }

--- a/fluxfw-gcp/tf/modules/compute/main.tf
+++ b/fluxfw-gcp/tf/modules/compute/main.tf
@@ -48,13 +48,15 @@ resource "google_compute_resource_policy" "collocated" {
     project = var.project_id
     region  = var.region
     group_placement_policy {
-      vm_count = var.num_instances
+      vm_count    = var.num_instances
       collocation = "COLLOCATED"
     }
 }
 
 module "flux_compute_instance_template" {
-    source               = "github.com/terraform-google-modules/terraform-google-vm/modules/instance_template"
+    source  = "terraform-google-modules/vm/google//modules/instance_template"
+    version = "~> 10.1"
+
     region               = var.region
     project_id           = var.project_id
     name_prefix          = var.name_prefix
@@ -69,7 +71,7 @@ module "flux_compute_instance_template" {
     automatic_restart    = local.automatic_restart
     on_host_maintenance  = local.on_host_maintenance
 
-    metadata             = { 
+    metadata = {
         "boot-script"      : var.boot_script
         "login-node-specs" : var.login_node_specs
         "enable-oslogin"   : "TRUE",
@@ -81,7 +83,9 @@ module "flux_compute_instance_template" {
 }
 
 module "flux_compute_instances" {
-    source              = "github.com/terraform-google-modules/terraform-google-vm/modules/compute_instance"
+    source  = "terraform-google-modules/vm/google//modules/compute_instance"
+    version = "~> 10.1"
+
     region              = var.region
     zone                = data.google_compute_zones.available.names[0]
     hostname            = var.name_prefix

--- a/fluxfw-gcp/tf/modules/login/main.tf
+++ b/fluxfw-gcp/tf/modules/login/main.tf
@@ -32,7 +32,9 @@ locals {
 }
 
 module "flux_login_instance_template" {
-    source               = "github.com/terraform-google-modules/terraform-google-vm/modules/instance_template"
+    source  = "terraform-google-modules/vm/google//modules/instance_template"
+    version = "~> 10.1"
+
     region               = var.region
     project_id           = var.project_id
     name_prefix          = var.name_prefix
@@ -54,7 +56,9 @@ module "flux_login_instance_template" {
 }
 
 module "flux_login_instances" {
-    source              = "github.com/terraform-google-modules/terraform-google-vm/modules/compute_instance"
+    source  = "terraform-google-modules/vm/google//modules/compute_instance"
+    version = "~> 10.1"
+
     region              = var.region
     zone                = data.google_compute_zones.available.names[0]
     hostname            = var.name_prefix

--- a/fluxfw-gcp/tf/modules/management/main.tf
+++ b/fluxfw-gcp/tf/modules/management/main.tf
@@ -18,7 +18,9 @@ data "google_compute_image" "fluxfw_manager_image" {
 }
 
 module "flux_manager_instance_template" {
-    source               = "github.com/terraform-google-modules/terraform-google-vm/modules/instance_template"
+    source  = "terraform-google-modules/vm/google//modules/instance_template"
+    version = "~> 10.1"
+
     region               = var.region
     project_id           = var.project_id
     name_prefix          = "${var.name_prefix}-manager"
@@ -29,20 +31,22 @@ module "flux_manager_instance_template" {
     disk_size_gb         = 1024
     source_image         = data.google_compute_image.fluxfw_manager_image.self_link
     source_image_project = data.google_compute_image.fluxfw_manager_image.project
-    metadata             = {
-        "enable-oslogin"     : "TRUE",
-        "VmDnsSetting"       : "GlobalDefault"
-        "nfs-mounts"         : jsonencode(var.nfs_mounts)
+    metadata = {
+        "enable-oslogin" : "TRUE",
+        "VmDnsSetting" : "GlobalDefault"
+        "nfs-mounts" : jsonencode(var.nfs_mounts)
         "compute-node-specs" : var.compute_node_specs
-        "login-node-specs"   : var.login_node_specs
+        "login-node-specs" : var.login_node_specs
     }
 }
 
 module "flux_manager_instance" {
-    source              = "github.com/terraform-google-modules/terraform-google-vm/modules/compute_instance"
-    region              = var.region
-    hostname            = "${var.name_prefix}-manager"
-    num_instances       = 1
-    instance_template   = module.flux_manager_instance_template.self_link
-    subnetwork          = var.subnetwork
+    source  = "terraform-google-modules/vm/google//modules/compute_instance"
+    version = "~> 10.1"
+
+    region            = var.region
+    hostname          = "${var.name_prefix}-manager"
+    num_instances     = 1
+    instance_template = module.flux_manager_instance_template.self_link
+    subnetwork        = var.subnetwork
 }


### PR DESCRIPTION
The release of [v11.0.0 of the CFT vm module](https://github.com/terraform-google-modules/terraform-google-vm/releases/tag/v11.0.0) has broken GoogleCloudPlatform/hpc-toolkit blueprint using these modules because the Toolkit does not yet support Terraform Provider Google 5.x series.

These version constraints allow Toolkit 4.x blueprints to function while allowing other clients to adopt TPG 5.x.