### PR TITLE
Update  base image version for apptainer cluster examle

### DIFF
--- a/apptainer/cluster/slurm-apptainer.yaml
+++ b/apptainer/cluster/slurm-apptainer.yaml
@@ -27,7 +27,7 @@ vars:
   login_machine_type: e2-standard-4
   custom_image_family: apptainer-enabled
   instance_image:
-    family: slurm-gcp-5-9-hpc-rocky-linux-8
+    family: slurm-gcp-5-10-hpc-rocky-linux-8
     project: schedmd-slurm-public
   instance_image_custom: true
 

--- a/apptainer/cluster/slurm-apptainer.yaml
+++ b/apptainer/cluster/slurm-apptainer.yaml
@@ -64,7 +64,7 @@ deployment_groups:
     - apptainer_installation
     settings:
       source_image_project_id: [schedmd-slurm-public]
-      source_image_family: slurm-gcp-5-9-hpc-rocky-linux-8 
+      source_image_family: slurm-gcp-5-10-hpc-rocky-linux-8 
       disk_size: $(vars.disk_size)
       image_family: $(vars.custom_image_family)
       state_timeout: 20m


### PR DESCRIPTION
Fix: #70 
from  slurm-gcp-5-9-hpc-rocky-linux-8-1707957597 
to slurm-gcp-5-10-hpc-rocky-linux-8-1707957597
Signed-off-by: Yoshiaki Senda <yoshiaki@live.it>