### PR TITLE
Update README.md

### DIFF
--- a/apptainer/builders/cloud/README.md
+++ b/apptainer/builders/cloud/README.md
@@ -172,7 +172,7 @@ export REPOSITORY_URL=oras://#LOCATION#/#PROJECT_NAME#/#REPOSITORY_NAME#
 Apptainer needs to authenticate to your repository before it can push or pull images. Use this command to authenticate
 
 ```bash
-apptainer remote login \
+apptainer repository login \
 --username=oauth2accesstoken \
 --password=$(gcloud auth print-access-token) \ 
 ${REPOSITORY_URL}

--- a/apptainer/builders/cloud/README.md
+++ b/apptainer/builders/cloud/README.md
@@ -172,7 +172,7 @@ export REPOSITORY_URL=oras://#LOCATION#/#PROJECT_NAME#/#REPOSITORY_NAME#
 Apptainer needs to authenticate to your repository before it can push or pull images. Use this command to authenticate
 
 ```bash
-apptainer repository login \
+apptainer registry login \
 --username=oauth2accesstoken \
 --password=$(gcloud auth print-access-token) \ 
 ${REPOSITORY_URL}

--- a/apptainer/builders/instance/README.md
+++ b/apptainer/builders/instance/README.md
@@ -172,7 +172,7 @@ export REPOSITORY_URL=<ARTIFACT REGISTRY REPOSITORY URL> # e.g. oras://us-docker
 Apptainer needs to authenticate to your repository before it can push or pull images. Use this command to authenticate
 
 ```bash
-apptainer remote login \
+apptainer registry login \
 --username=oauth2accesstoken \
 --password=$(gcloud auth print-access-token) \ 
 ${REPOSITORY_URL}


### PR DESCRIPTION
Apptainer remote login step provides warning and also fails in some scenario as it is deprecated  WARNING: 'remote login' is deprecated for registries or keyservers and will be removed in a future release; running 'registry login'

Updated it with registry login