### PR TITLE
Update NAMD on Slurm solution to add missing files, update to the latest image, and to add VMD to Qwiklab blueprint.

### DIFF
--- a/hcls/namd-on-slurm/namd-slurm-qwiklab.yaml
+++ b/hcls/namd-on-slurm/namd-slurm-qwiklab.yaml
@@ -149,6 +149,8 @@ deployment_groups:
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network]
     settings:
+      dws_flex:
+        max_run_duration: 3600 # 1 hour
       zones: $(vars.zones)
       node_count_dynamic_max: 16
       disk_size_gb: $(vars.disk_size)
@@ -170,6 +172,8 @@ deployment_groups:
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network]
     settings:
+      dws_flex:
+        max_run_duration: 3600 # 1 hour
       zones: $(vars.zones)
       node_count_dynamic_max: 20
       disk_size_gb: $(vars.disk_size)
@@ -192,6 +196,8 @@ deployment_groups:
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network]
     settings:
+      dws_flex:
+        max_run_duration: 3600 # 1 hour
       zones: $(vars.zones)
       node_count_dynamic_max: 16
       disk_size_gb: $(vars.disk_size)
@@ -213,6 +219,8 @@ deployment_groups:
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network]
     settings:
+      dws_flex:
+        max_run_duration: 3600 # 1 hour
       zones: $(vars.zones)
       node_count_dynamic_max: 20
       disk_size_gb: $(vars.disk_size)

--- a/hcls/namd-on-slurm/namd-slurm-qwiklab.yaml
+++ b/hcls/namd-on-slurm/namd-slurm-qwiklab.yaml
@@ -103,6 +103,28 @@ deployment_groups:
 
 - group: cluster
   modules:
+  
+  ### Remote Desktop ###
+
+  - id: desktop
+    source: community/modules/remote-desktop/chrome-remote-desktop
+    use:
+    - network
+    - data_bucket
+    - homefs
+    settings:
+      add_deployment_name_before_prefix: true
+      name_prefix: chrome-remote-desktop
+      install_nvidia_driver: true
+      startup_script: |
+        wget https://www.ks.uiuc.edu/Research/vmd/alpha/vmd-2.0.0a5.bin.LINUXAMD64.tar.gz
+        tar xvzf vmd-2.0.0a5.bin.LINUXAMD64.tar.gz ./
+        #find /user_provided_software -name vmd-1.9.*.bin.LINUXAMD64*.tar.gz -exec tar xvzf '{}' -C . \;
+        cd vmd-2.0.*/
+        ./configure
+        cd src/
+        sudo make install
+  
   - id: compute_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network]

--- a/hcls/namd-on-slurm/namd-slurm-qwiklab.yaml
+++ b/hcls/namd-on-slurm/namd-slurm-qwiklab.yaml
@@ -29,7 +29,6 @@ vars:
   image_name: apptainer-enabled-20250330t224234z
   image_project: qwiklabs-resources
   instance_image_custom: true
-  zones: [us-central1-a, us-central1-b, us-central1-c]
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -127,7 +126,6 @@ deployment_groups:
     use: [network]
     settings:
       node_count_dynamic_max: 20
-      zones: $(vars.zones)
       disk_size_gb: $(vars.disk_size)
       bandwidth_tier: gvnic_enabled
       allow_automatic_updates: false
@@ -148,7 +146,7 @@ deployment_groups:
     settings:
       dws_flex:
         max_run_duration: 3600 # 1 hour
-      zones: $(vars.zones)
+      enable_placement: false
       node_count_dynamic_max: 16
       disk_size_gb: $(vars.disk_size)
       machine_type: g2-standard-16
@@ -171,7 +169,7 @@ deployment_groups:
     settings:
       dws_flex:
         max_run_duration: 3600 # 1 hour
-      zones: $(vars.zones)
+      enable_placement: false
       node_count_dynamic_max: 20
       disk_size_gb: $(vars.disk_size)
       machine_type: a2-highgpu-1g
@@ -195,7 +193,7 @@ deployment_groups:
     settings:
       dws_flex:
         max_run_duration: 3600 # 1 hour
-      zones: $(vars.zones)
+      enable_placement: false
       node_count_dynamic_max: 16
       disk_size_gb: $(vars.disk_size)
       machine_type: g2-standard-48
@@ -218,7 +216,7 @@ deployment_groups:
     settings:
       dws_flex:
         max_run_duration: 3600 # 1 hour
-      zones: $(vars.zones)
+      enable_placement: false
       node_count_dynamic_max: 20
       disk_size_gb: $(vars.disk_size)
       machine_type: a2-highgpu-4g

--- a/hcls/namd-on-slurm/namd-slurm-qwiklab.yaml
+++ b/hcls/namd-on-slurm/namd-slurm-qwiklab.yaml
@@ -30,7 +30,6 @@ vars:
   image_project: qwiklabs-resources
   instance_image_custom: true
   zones: [us-central1-a, us-central1-b, us-central1-c]
-  
 
 # Documentation for each of the modules used below can be found at
 # https://github.com/GoogleCloudPlatform/hpc-toolkit/blob/main/modules/README.md
@@ -59,7 +58,6 @@ deployment_groups:
     source: modules/monitoring/dashboard
     settings:
       title: HPC
-
 
   - id: startup_login
     source: modules/scripts/startup-script
@@ -118,8 +116,7 @@ deployment_groups:
       install_nvidia_driver: true
       startup_script: |
         wget https://www.ks.uiuc.edu/Research/vmd/alpha/vmd-2.0.0a5.bin.LINUXAMD64.tar.gz
-        tar xvzf vmd-2.0.0a5.bin.LINUXAMD64.tar.gz ./
-        #find /user_provided_software -name vmd-1.9.*.bin.LINUXAMD64*.tar.gz -exec tar xvzf '{}' -C . \;
+        tar xvzf vmd-2.0.0a5.bin.LINUXAMD64.tar.gz
         cd vmd-2.0.*/
         ./configure
         cd src/

--- a/hcls/namd-on-slurm/namd-slurm.yaml
+++ b/hcls/namd-on-slurm/namd-slurm.yaml
@@ -128,6 +128,27 @@ deployment_groups:
 
 - group: cluster
   modules:
+
+  ### Remote Desktop ###
+
+  - id: desktop
+    source: community/modules/remote-desktop/chrome-remote-desktop
+    use:
+    - network
+    - data_bucket
+    - homefs
+    settings:
+      add_deployment_name_before_prefix: true
+      name_prefix: chrome-remote-desktop
+      install_nvidia_driver: true
+      startup_script: |
+        wget https://www.ks.uiuc.edu/Research/vmd/alpha/vmd-2.0.0a5.bin.LINUXAMD64.tar.gz
+        tar xvzf vmd-2.0.0a5.bin.LINUXAMD64.tar.gz
+        cd vmd-2.0.*/
+        ./configure
+        cd src/
+        sudo make install
+  
   - id: compute_nodeset
     source: community/modules/compute/schedmd-slurm-gcp-v6-nodeset
     use: [network]

--- a/hcls/namd-on-slurm/namd-slurm.yaml
+++ b/hcls/namd-on-slurm/namd-slurm.yaml
@@ -119,7 +119,7 @@ deployment_groups:
     settings:
       source_image_project_id: [schedmd-slurm-public]
       # see latest in https://github.com/GoogleCloudPlatform/slurm-gcp/blob/master/docs/images.md#published-image-family
-      source_image_family: slurm-gcp-6-8-hpc-rocky-linux-8
+      source_image_family: slurm-gcp-6-9-hpc-rocky-linux-8
       # You can find size of source image by using following command
       # gcloud compute images describe-from-family <source_image_family> --project schedmd-slurm-public
       disk_size: $(vars.disk_size)

--- a/hcls/namd-on-slurm/namd_apoa1.job
+++ b/hcls/namd-on-slurm/namd_apoa1.job
@@ -1,0 +1,12 @@
+#!/bin/bash
+#SBATCH --job-name=namd_ipoa1_benchmark
+#SBATCH --partition=a2
+#SBATCH --output=%3A/out.txt
+#SBATCH --error=%3A/err.txt
+
+# Build SIF, if it doesn't exist
+if [[ ! -f namd.sif ]]; then
+  export NAMD_TAG=3.0-beta5
+  apptainer build namd.sif docker://nvcr.io/hpc/namd:$NAMD_TAG 
+fi
+apptainer run --nv namd.sif namd3 +p64 +devices 0,1,2,3 +setcpuaffinity apoa1_gpu/apoa1_gpures_npt.namd

--- a/hcls/namd-on-slurm/namd_stmv.job
+++ b/hcls/namd-on-slurm/namd_stmv.job
@@ -1,0 +1,12 @@
+#!/bin/bash
+#SBATCH --job-name=namd_stmv_benchmark
+#SBATCH --partition=a2
+#SBATCH --output=%3A/out.txt
+#SBATCH --error=%3A/err.txt
+
+# Build SIF, if it doesn't exist
+if [[ ! -f namd.sif ]]; then
+  export NAMD_TAG=3.0-beta5
+  apptainer build namd.sif docker://nvcr.io/hpc/namd:$NAMD_TAG 
+fi
+apptainer run --nv namd.sif namd3 +p32 +setcpuaffinity +devices 0,1,2,3 stmv_gpu/stmv_gpuoff_npt.namd


### PR DESCRIPTION
Updating the NAMD on Slurm solution to add two missing job files needed for namd-slurm.yaml, to update namd-slurm.yaml to use the latest image, which resolves a fatal Python syntax error that breaks Slurm setup, and to add VMD to the Qwiklab blueprint. The Qwiklab blueprint's image still needs updating to use the latest image and resolve the same fatal python syntax error.